### PR TITLE
Add button to generate Connector Settings

### DIFF
--- a/india_banking_connector/connectors/doctype/connector_settings/connector_settings.js
+++ b/india_banking_connector/connectors/doctype/connector_settings/connector_settings.js
@@ -3,16 +3,34 @@
 
 frappe.ui.form.on("Connector Settings", {
 	refresh(frm) {
-        frappe.call("india_banking_connector.utils.get_default_connectors").then(r => {
-            frm.set_query("connector", "connectors", function(frm, cdt, cdn) {
-                console.log(r.message);
-                return {
-                    filters: {
-                        "name": ['in', r.message]
-                    }
-                }
-            });
-        });
-        
-    }
+		if (!frm?.grids[0]?.grid?.data?.length) {
+			frm.add_custom_button(__("Generate Connector Settings"), function () {
+				// When this button is clicked,
+				frappe.call({
+					method: "india_banking_connector.install.create_connector_settings",
+					freeze: true,
+					freeze_message: __("Generating Connector Settings..."),
+					callback: function (r) {
+						frappe.show_alert({
+							message: __("Connector Settings Regenerated"),
+							indicator: "green",
+						});
+
+						frm.reload_doc();
+					},
+				});
+			});
+
+			frappe.call("india_banking_connector.utils.get_default_connectors").then(r => {
+				frm.set_query("connector", "connectors", function (frm, cdt, cdn) {
+					console.log(r.message);
+					return {
+						filters: {
+							"name": ['in', r.message]
+						}
+					}
+				});
+			});
+		}
+	}
 });

--- a/india_banking_connector/india_banking_connector/doctype/bank_api_endpoint/bank_api_endpoint_list.js
+++ b/india_banking_connector/india_banking_connector/doctype/bank_api_endpoint/bank_api_endpoint_list.js
@@ -2,19 +2,19 @@
 // For license information, please see license.txt
 
 frappe.listview_settings["Bank API Endpoint"] = {
-  onload: function (listview) {
-    listview.page.add_inner_button(__("Regenerate API Endpoint"), () => {
-      frappe.call({
-        method: "india_banking_connector.install.create_bank_api_endpoint",
-        callback: function (r) {
-          if (r.message) {
-            frappe.show_alert({
-              message: __("API Endpoints Regenerated"),
-              indicator: "green",
-            });
-          }
-        },
-      });
-    });
-  },
+	onload: (listview) => {
+		listview.page.add_inner_button(__("Regenerate API Endpoints"), () => {
+			frappe.call({
+				method: "india_banking_connector.install.create_bank_api_endpoint",
+				callback: (r) => {
+					if (!r.err && !r.error) {
+						frappe.show_alert({
+							message: __("API Endpoints Regenerated. Please refresh this page."),
+							indicator: "green",
+						});
+					}
+				},
+			});
+		});
+	},
 };

--- a/india_banking_connector/install.py
+++ b/india_banking_connector/install.py
@@ -27,7 +27,7 @@ def create_default_bank():
 			bank_doc.is_standard = 1
 			bank_doc.save()
 
-
+@frappe.whitelist()
 def create_connector_settings():
 	click.echo(" -> Updating Connector Settings")
 	settings_doc = frappe.get_doc("Connector Settings")


### PR DESCRIPTION
Added a button to generate _Connector Settings_ similar to _Bank API Endpoints_. This is necessary because, in some cases, the required migration is skipped and the connector settings are not populated as intended. The code paths to make the necessary API calls fail because the required DocType for a given bank cannot be found.

To overcome this, a "Generate Connector Settings" button is added to the _Connector Settings_ DocType page that appears when the _Connector Map_ table is empty. Once this button is clicked, the migration is manually run, and the _Connector Maps_ are populated. Once the population is done, the button disappears.