### PR TITLE
fix(hdfc): UTR fallback to include TXN_REFERENCE_NO for all transfer types

### DIFF
--- a/india_banking_connector/__init__.py
+++ b/india_banking_connector/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "15.2.0"
+__version__ = "15.2.1"
 __title__ = "India Banking Connector"

--- a/india_banking_connector/connectors/doctype/hdfc_connector/hdfc_connector.py
+++ b/india_banking_connector/connectors/doctype/hdfc_connector/hdfc_connector.py
@@ -195,13 +195,13 @@ class HDFCConnector(BankConnector):
 
 			if record:
 				if "TXN_STATUS" in record and record["TXN_STATUS"]:
-					utr = record.get("UTR_NO", None)
+					utr = record.get("UTR_NO", None) or record.get("TXN_REFERENCE_NO")
 					if (
 						not utr
 						and record["TXN_STATUS"] == "Processed"
 						and record["TRANSFER_TYPE"] == "Intra Bank Transfer"
 					):
-						utr = record.get("TXN_REFERENCE_NO") or record.get(
+						utr = record.get(
 							"PAYMENTREFNO"
 						)
 


### PR DESCRIPTION
## Summary

- Adds `TXN_REFERENCE_NO` as a UTR fallback for all HDFC transfer types, not just specific ones
- Bumps version to v15.2.1

## Test plan

- [ ] Verify HDFC payment status response correctly picks up `TXN_REFERENCE_NO` as UTR when primary UTR field is absent
- [ ] Confirm no regression for existing HDFC transfer types (NEFT, RTGS, IMPS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)