### PR TITLE
fix: normalize RSA key line endings to handle Mac-created PEM files

### DIFF
--- a/india_banking_connector/__init__.py
+++ b/india_banking_connector/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "15.2.2"
+__version__ = "15.2.3"
 __title__ = "India Banking Connector"

--- a/india_banking_connector/__init__.py
+++ b/india_banking_connector/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "15.2.1"
+__version__ = "15.2.2"
 __title__ = "India Banking Connector"

--- a/india_banking_connector/connectors/doctype/icici_connector/icici_connector.json
+++ b/india_banking_connector/connectors/doctype/icici_connector/icici_connector.json
@@ -15,6 +15,7 @@
   "corp_id",
   "aggr_id",
   "aggr_name",
+  "alias_id",
   "urn",
   "ifsc_code",
   "ip_address",
@@ -105,6 +106,11 @@
    "reqd": 1
   },
   {
+   "fieldname": "alias_id",
+   "fieldtype": "Data",
+   "label": "Alias ID"
+  },
+  {
    "fieldname": "amended_from",
    "fieldtype": "Link",
    "label": "Amended From",
@@ -136,6 +142,7 @@
    "label": "Testing"
   },
   {
+   "description": "ICICI branch IFSC code used for intra-bank (ICICI to ICICI) transfers. Defaults to ICIC0000011 if not set.",
    "fieldname": "ifsc_code",
    "fieldtype": "Data",
    "label": "IFSC Code"

--- a/india_banking_connector/connectors/doctype/icici_connector/icici_connector.py
+++ b/india_banking_connector/connectors/doctype/icici_connector/icici_connector.py
@@ -134,7 +134,7 @@ class ICICIConnector(BankConnector):
 			unique_id=unique_id,
 			connector=self,
 		)
-		
+
 		return self.get_decrypted_response(
 			response, method="make_payment", log_id=log_id
 		)
@@ -545,11 +545,11 @@ class ICICIConnector(BankConnector):
 						"message": data.MESSAGE or "Payment Pending",
 					}
 				}
-			elif data.STATUS == "FAILURE":
+			elif data.STATUS in ["FAILURE", "REJECTED"]:
 				res_dict.payment_status = "PROCESSED"
 				res_dict.summary_details = {
 					self.payment_doc.name: {
-						"status": "Failed",
+						"status": "Failed" if data.STATUS == "FAILURE" else "Rejected",
 						"message": data.MESSAGE or "Payment Failed",
 					}
 				}

--- a/india_banking_connector/connectors/doctype/icici_connector/icici_connector.py
+++ b/india_banking_connector/connectors/doctype/icici_connector/icici_connector.py
@@ -253,7 +253,7 @@ class ICICIConnector(BankConnector):
 				"CORPID": connector_doc.corp_id,
 				"USERID": connector_doc.corp_usr,
 				"URN": connector_doc.urn,
-				"ALIASID": "",
+				"ALIASID": connector_doc.alias_id or "",
 			}
 		)
 

--- a/india_banking_connector/connectors/doctype/icici_connector/icici_connector.py
+++ b/india_banking_connector/connectors/doctype/icici_connector/icici_connector.py
@@ -649,9 +649,12 @@ class ICICIConnector(BankConnector):
 				if isinstance(records, dict):
 					records = [records]
 				for txn in records:
+					amount = abs(flt(txn.get("AMOUNT")))
+					if cstr(txn.get("TYPE")).lower() == "dr":
+						amount = -1 * amount
 					transaction = {
 						"transaction_date": txn.get("TXNDATE", ""),
-						"transaction_amount": txn.get("AMOUNT"),
+						"transaction_amount": amount,
 						"reference_number": txn.get("TRANSACTIONID")
 						or txn.get("CHEQUENO"),
 						"transaction_description": txn.get("REMARKS", ""),


### PR DESCRIPTION
## Summary

- Normalize `\r\n` and `\r` line endings to `\n` before passing PEM key content to RSA parsers in all 4 key-reading methods (`rsa_encrypt_key`, `rsa_decrypt_key`, `rsa_encrypt_data`, `rsa_decrypt_data`)
- Also fixes an unclosed file handle in `rsa_encrypt_data` (switched from bare `open()` to `with` block)

**Root cause:** PEM key files created on macOS can have `\r` or `\r\n` line endings. PyCryptodome's `RSA.importKey()` and the `rsa` library's `load_pkcs1()` raise `ValueError: RSA key format is not supported` when encountering non-Unix line endings.