### PR TITLE
feat(icici): add alias_id field and ifsc_code description

### DIFF
--- a/india_banking_connector/__init__.py
+++ b/india_banking_connector/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "15.2.1"
+__version__ = "15.2.2"
 __title__ = "India Banking Connector"

--- a/india_banking_connector/connectors/doctype/icici_connector/icici_connector.json
+++ b/india_banking_connector/connectors/doctype/icici_connector/icici_connector.json
@@ -15,6 +15,7 @@
   "corp_id",
   "aggr_id",
   "aggr_name",
+  "alias_id",
   "urn",
   "ifsc_code",
   "ip_address",
@@ -105,6 +106,11 @@
    "reqd": 1
   },
   {
+   "fieldname": "alias_id",
+   "fieldtype": "Data",
+   "label": "Alias ID"
+  },
+  {
    "fieldname": "amended_from",
    "fieldtype": "Link",
    "label": "Amended From",
@@ -136,6 +142,7 @@
    "label": "Testing"
   },
   {
+   "description": "ICICI branch IFSC code used for intra-bank (ICICI to ICICI) transfers. Defaults to ICIC0000011 if not set.",
    "fieldname": "ifsc_code",
    "fieldtype": "Data",
    "label": "IFSC Code"

--- a/india_banking_connector/connectors/doctype/icici_connector/icici_connector.py
+++ b/india_banking_connector/connectors/doctype/icici_connector/icici_connector.py
@@ -253,7 +253,7 @@ class ICICIConnector(BankConnector):
 				"CORPID": connector_doc.corp_id,
 				"USERID": connector_doc.corp_usr,
 				"URN": connector_doc.urn,
-				"ALIASID": "",
+				"ALIASID": connector_doc.alias_id or "",
 			}
 		)
 


### PR DESCRIPTION
- Added `alias_id` (Alias ID) field to ICICI Connector for dynamic `ALIASID` in UPI mandate registration payload
- Added description to `ifsc_code` field clarifying its use for intra-bank transfers