### PR TITLE
Feature/indusind bank connector

### DIFF
--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.js
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.js
@@ -1,0 +1,10 @@
+// Copyright (c) 2026, Aerele Technologies Private Limited and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("IndusInd Bank Connector", {
+	reset_endpoints(frm) {
+		frm.call("reset_endpoints").then(() => {
+			frm.dirty();
+		});
+	},
+});

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.json
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.json
@@ -116,13 +116,13 @@
    "fieldtype": "Section Break"
   },
   {
-   "description": "<div class=\"api-url-format\">\n    <p><strong>URL Format:</strong> &lt;Base-URL&gt;/&lt;API-Path&gt;</p>\n\n    <p><strong>Examples:</strong></p>\n\n    <ul>\n<li><strong>host</strong> → api.indusind.com</li>\n        <li><strong>make_payment</strong> → https://api.indusind.com/uat/batch/transactionposting/V1</li>\n        <li><strong>payment_status</strong> → https://api.indusind.com/uat/batch/transactionenquiry/V1</li>\n    </ul>\n</div>",
+   "description": "<div class=\"api-url-format\">\n    <p><strong>URL Format:</strong> &lt;Base-URL&gt;/&lt;API-Path&gt;</p>\n\n    <p><strong>UAT examples:</strong></p>\n\n    <ul>\n<li><strong>host</strong> → indusapiuat.indusind.bank.in</li>\n        <li><strong>make_payment</strong> → https://indusapiuat.indusind.bank.in/indusapi-np/uat/batch/transactionposting/V1</li>\n        <li><strong>payment_status</strong> → https://indusapiuat.indusind.bank.in/indusapi-np/uat/batch/transactionenquiry/V1</li>\n        <li><strong>beneficiary_request</strong> → https://indusapiuat.indusind.bank.in/indusapi-np/uat/batch/beneficiaryrequest/V1</li>\n        <li><strong>beneficiary_enquiry</strong> → https://indusapiuat.indusind.bank.in/indusapi-np/uat/batch/beneficiaryenquiry (no /V1 suffix)</li>\n    </ul>\n</div>",
    "fieldname": "api_endpoints",
    "fieldtype": "Table",
    "options": "Endpoint URLs"
   },
   {
-   "description": "<p><strong>Base URL:</strong> https://api.indusind.com</p>",
+   "description": "<p><strong>UAT Base URL:</strong> https://indusapiuat.indusind.bank.in</p>",
    "fieldname": "base_url",
    "fieldtype": "Data",
    "label": "Base URL"

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.json
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.json
@@ -1,0 +1,175 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:account_number",
+ "creation": "2026-06-18 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "active",
+  "account_number",
+  "customer_id",
+  "maker_id",
+  "checker_id",
+  "column_break_auth",
+  "testing",
+  "client_id",
+  "client_secret",
+  "aes_key",
+  "iv",
+  "pay_mode",
+  "stp_enabled",
+  "tab_2_tab",
+  "api_endpoints_section",
+  "base_url",
+  "api_endpoints",
+  "reset_endpoints",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "default": "0",
+   "fieldname": "active",
+   "fieldtype": "Check",
+   "label": "Active"
+  },
+  {
+   "fieldname": "account_number",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Account Number",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "customer_id",
+   "fieldtype": "Data",
+   "label": "Customer ID",
+   "reqd": 1
+  },
+  {
+   "fieldname": "maker_id",
+   "fieldtype": "Data",
+   "label": "Maker ID",
+   "reqd": 1
+  },
+  {
+   "fieldname": "checker_id",
+   "fieldtype": "Data",
+   "label": "Checker ID",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_auth",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "testing",
+   "fieldtype": "Check",
+   "label": "Testing"
+  },
+  {
+   "fieldname": "client_id",
+   "fieldtype": "Password",
+   "label": "Client Id",
+   "reqd": 1
+  },
+  {
+   "fieldname": "client_secret",
+   "fieldtype": "Password",
+   "label": "Client Secret",
+   "reqd": 1
+  },
+  {
+   "fieldname": "aes_key",
+   "fieldtype": "Password",
+   "label": "AES Key (hex)",
+   "reqd": 1
+  },
+  {
+   "fieldname": "iv",
+   "fieldtype": "Password",
+   "label": "AES IV (hex)",
+   "reqd": 1
+  },
+  {
+   "default": "I",
+   "fieldname": "pay_mode",
+   "fieldtype": "Select",
+   "label": "Pay Mode",
+   "options": "B\nI"
+  },
+  {
+   "default": "0",
+   "fieldname": "stp_enabled",
+   "fieldtype": "Check",
+   "label": "STP Enabled"
+  },
+  {
+   "fieldname": "tab_2_tab",
+   "fieldtype": "Tab Break",
+   "label": "API Endpoints"
+  },
+  {
+   "fieldname": "api_endpoints_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "description": "<div class=\"api-url-format\">\n    <p><strong>URL Format:</strong> &lt;Base-URL&gt;/&lt;API-Path&gt;</p>\n\n    <p><strong>Examples:</strong></p>\n\n    <ul>\n<li><strong>host</strong> → api.indusind.com</li>\n        <li><strong>make_payment</strong> → https://api.indusind.com/uat/batch/transactionposting/V1</li>\n        <li><strong>payment_status</strong> → https://api.indusind.com/uat/batch/transactionenquiry/V1</li>\n    </ul>\n</div>",
+   "fieldname": "api_endpoints",
+   "fieldtype": "Table",
+   "options": "Endpoint URLs"
+  },
+  {
+   "description": "<p><strong>Base URL:</strong> https://api.indusind.com</p>",
+   "fieldname": "base_url",
+   "fieldtype": "Data",
+   "label": "Base URL"
+  },
+  {
+   "fieldname": "reset_endpoints",
+   "fieldtype": "Button",
+   "label": "Reset Endpoints"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "IndusInd Bank Connector",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2026-06-18 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Connectors",
+ "name": "IndusInd Bank Connector",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
@@ -240,7 +240,14 @@ class IndusIndBankConnector(BankConnector):
 
 	def _payment_row(self, row):
 		row = frappe._dict(row)
-		tran_type = self._tran_type(row.mode_of_transfer)
+		# Prefer the mode the user actually chose in the "Initiate Payment"
+		# dialog (Payment Order.default_mode_of_transfer) over the per-row
+		# mode india_banking derived from its amount-slab lookup, which
+		# silently overrides an explicit NEFT/RTGS choice for small amounts
+		# that also fall inside IMPS's range.
+		tran_type = self._tran_type(
+			self.doc.get("default_mode_of_transfer") or row.mode_of_transfer
+		)
 
 		return {
 			"tranType": tran_type,

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
@@ -4,13 +4,48 @@
 import hashlib
 import hmac
 import json
+import re
 from base64 import b64decode, b64encode
 
+import frappe
+import requests
 from Crypto.Cipher import AES
+from frappe import _
 
 from india_banking_connector.connectors.bank_connector import BankConnector
+from india_banking_connector.india_banking_connector.doctype.bank_request_log.bank_request_log import (
+	create_api_log,
+)
 
 GCM_TAG_LENGTH = 16
+POSTING_ACCEPTED_CODE = "R000"
+
+# Mode of Transfer -> IndusInd tranType. IFTO (Internal/A2A) addresses the
+# beneficiary by IblAcctNo instead of IFSC + account number.
+TRAN_TYPE = {
+	"imps": "IMPS",
+	"neft": "NEFT",
+	"rtgs": "RTGS",
+	"a2a": "IFTO",
+}
+
+# IndusInd TransactionEnquiry StatusCode -> Payment Order Summary payment_status.
+# SP/UP/N/P/PR/FA/SW are deliberately non-final (mapped to Pending): re-initiating
+# on these causes double payments. J/F vs R/RE -> Failed/Rejected is a judgment
+# call pending bank confirmation (the H2H doc groups all four as one bucket).
+STATUS = {
+	"S": "Processed",
+	"UP": "Pending",
+	"N/P": "Pending",
+	"PR": "Pending",
+	"SP": "Pending",
+	"FA": "Pending",
+	"SW": "Pending",
+	"J": "Failed",
+	"F": "Failed",
+	"R": "Rejected",
+	"RE": "Rejected",
+}
 
 
 class IndusIndBankConnector(BankConnector):
@@ -20,6 +55,11 @@ class IndusIndBankConnector(BankConnector):
 	# doesn't provide (it only has CBC and JWE-wrapped GCM). Byte layout below
 	# (ciphertext|tag, fixed IV from the `iv` field) is per the H2H doc and is
 	# unverified against a live UAT sample — confirm before a real UAT call.
+
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.doc = frappe._dict(kwargs.get("doc", {}))
+		self.account_config = {}
 
 	def _aes_key(self) -> bytes:
 		return bytes.fromhex(self.get_password("aes_key"))
@@ -45,3 +85,162 @@ class IndusIndBankConnector(BankConnector):
 		plain = json.dumps(body, separators=(",", ":"))
 		msg_key, hash_key = ("requestMsg", "requestHash") if lower else ("RequestMsg", "RequestHash")
 		return {msg_key: self._encrypt(plain), hash_key: self._hash(plain)}
+
+	@property
+	def headers(self):
+		return {
+			"IBL-Client-Id": self.get_password("client_id"),
+			"IBL-Client-Secret": self.get_password("client_secret"),
+			"Content-Type": "application/json",
+		}
+
+	# ---- operations (poll-based: TransactionPosting ack, then TransactionEnquiry) ----
+
+	def initiate_payment(self):
+		unique_id = self._unique_id()
+		if existing := self.validate_duplicate_payments(unique_id=unique_id):
+			return existing
+
+		payload = self.get_encrypted_payload("make_payment")
+		response = requests.post(self.urls.make_payment, headers=self.headers, json=payload)
+
+		log_id = create_api_log(
+			response,
+			action="Initiate Payment",
+			account_config=self.account_config,
+			ref_doctype=self.doc.doctype,
+			ref_docname=self.doc.name,
+			unique_id=unique_id,
+			connector=self,
+		)
+		return self.get_decrypted_response(response, method="make_payment", log_id=log_id)
+
+	def get_payment_status(self):
+		payload = self.get_encrypted_payload("payment_status")
+		response = requests.post(self.urls.payment_status, headers=self.headers, json=payload)
+
+		log_id = create_api_log(
+			response,
+			action="Payment Status",
+			account_config=self.account_config,
+			ref_doctype=self.doc.doctype,
+			ref_docname=self.doc.name,
+			unique_id=self._unique_id(),
+			connector=self,
+		)
+		return self.get_decrypted_response(response, method="payment_status", log_id=log_id)
+
+	def get_bank_balance(self):
+		frappe.throw(_("Not supported by IndusInd Batch API"))
+
+	def get_bank_statement(self):
+		frappe.throw(_("Not supported by IndusInd Batch API"))
+
+	# ---- payload builders ----
+
+	def get_encrypted_payload(self, method):
+		self.update_account_config(method)
+		return self._envelope(self.account_config["body"], lower=True)
+
+	def update_account_config(self, method):
+		{
+			"make_payment": self.set_payment_data,
+			"payment_status": self.set_payment_status_data,
+		}[method]()
+
+	def set_payment_data(self):
+		summary = self.doc.get("summary") or []
+		self.account_config["body"] = {
+			"multiPayReq": {
+				"header": {
+					"batchId": self._unique_id(),
+					"batchCount": str(len(summary)),
+					"batchAmount": str(self.doc.get("total")),
+					"makerId": self.maker_id,
+					"checkerId": self.checker_id,
+					"payMode": self.pay_mode or "I",
+					"custId": self.customer_id,
+					"debitAcctNumber": self.account_number,
+				},
+				"body": {"payment": [self._payment_row(row) for row in summary]},
+			}
+		}
+
+	def _payment_row(self, row):
+		row = frappe._dict(row)
+		tran_type = self._tran_type(row.mode_of_transfer)
+
+		payment = {
+			"tranType": tran_type,
+			"custRefNo": row.name,
+			"amount": row.amount,
+			"debitAcctNo": self.account_number,
+			"benName": self.clean_string(row.party_name or row.party),
+		}
+		if tran_type == "IFTO":
+			payment["IblAcctNo"] = row.bank_account_no
+		else:
+			payment["benIFSC"] = row.branch_code
+			payment["benAcctNo"] = row.bank_account_no
+		return payment
+
+	def _tran_type(self, mode_of_transfer):
+		mode = (mode_of_transfer or "").lower()
+		for key, tran_type in TRAN_TYPE.items():
+			if key in mode:
+				return tran_type
+		return "NEFT"
+
+	def set_payment_status_data(self):
+		self.account_config["body"] = {
+			"Customerid": self.customer_id,
+			"RefNo": self._unique_id(),
+			"IsBatch": "Y",
+		}
+
+	def _unique_id(self):
+		return "".join(re.findall(r"[0-9a-zA-Z]", self.doc.name))
+
+	# ---- response -> India Banking contract ----
+
+	def get_decrypted_response(self, response, method, log_id):
+		res = frappe._dict()
+		if not response.ok:
+			res.status = "Request Failure"
+			res.message = response.text
+			return res
+
+		data = response.json()
+		self.set_decrypted_response(log_id, json.dumps(data))
+		self.get_formated_response(data, res, method)
+		return res
+
+	def get_formated_response(self, data, res, method):
+		if isinstance(data, str):
+			data = json.loads(data)
+
+		if method == "make_payment":
+			self._format_payment_response(data, res)
+		elif method == "payment_status":
+			self._format_payment_status_response(data, res)
+
+	def _format_payment_response(self, data, res):
+		accepted = data.get("StatusCode") == POSTING_ACCEPTED_CODE
+		res.payment_status = "ACCEPTED" if accepted else "FAILED"
+		res.message = data.get("StatusDesc", "")
+		res.summary_details = self.get_summary_details("Accepted" if accepted else "Failed")
+
+	def _format_payment_status_response(self, data, res):
+		transactions = data.get("PayResp", {}).get("Transaction", [])
+		res.payment_status = "PROCESSED" if transactions else "Request Failure"
+		res.message = (
+			"Payment status fetched successfully." if transactions else "Invalid response format."
+		)
+		res.summary_details = {
+			txn.get("CustRefNo"): {
+				"status": STATUS.get(txn.get("StatusCode"), "Pending"),
+				"utr_number": txn.get("UTR", ""),
+				"message": txn.get("StatusDesc", ""),
+			}
+			for txn in transactions
+		}

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
@@ -274,7 +274,11 @@ class IndusIndBankConnector(BankConnector):
 	def _ben_mobile(self, row):
 		if not (row.party_type and row.party):
 			return ""
-		return frappe.db.get_value(row.party_type, row.party, "mobile_no") or ""
+		meta = frappe.get_meta(row.party_type)
+		for fieldname in ("mobile_no", "cell_number"):
+			if meta.has_field(fieldname):
+				return frappe.db.get_value(row.party_type, row.party, fieldname) or ""
+		return ""
 
 	def _tran_type(self, mode_of_transfer):
 		mode = (mode_of_transfer or "").lower()

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
@@ -1,8 +1,47 @@
 # Copyright (c) 2026, Aerele Technologies Private Limited and contributors
 # For license information, please see license.txt
 
+import hashlib
+import hmac
+import json
+from base64 import b64decode, b64encode
+
+from Crypto.Cipher import AES
+
 from india_banking_connector.connectors.bank_connector import BankConnector
+
+GCM_TAG_LENGTH = 16
 
 
 class IndusIndBankConnector(BankConnector):
 	bank = "IndusInd Bank"
+
+	# IndusInd's Batch API uses AES-256-GCM + HMAC-SHA256, which the base class
+	# doesn't provide (it only has CBC and JWE-wrapped GCM). Byte layout below
+	# (ciphertext|tag, fixed IV from the `iv` field) is per the H2H doc and is
+	# unverified against a live UAT sample — confirm before a real UAT call.
+
+	def _aes_key(self) -> bytes:
+		return bytes.fromhex(self.get_password("aes_key"))
+
+	def _aes_iv(self) -> bytes:
+		return bytes.fromhex(self.get_password("iv"))
+
+	def _encrypt(self, plain: str) -> str:
+		cipher = AES.new(self._aes_key(), AES.MODE_GCM, nonce=self._aes_iv())
+		ciphertext, tag = cipher.encrypt_and_digest(plain.encode())
+		return b64encode(ciphertext + tag).decode()
+
+	def _decrypt(self, blob: str) -> str:
+		raw = b64decode(blob)
+		ciphertext, tag = raw[:-GCM_TAG_LENGTH], raw[-GCM_TAG_LENGTH:]
+		cipher = AES.new(self._aes_key(), AES.MODE_GCM, nonce=self._aes_iv())
+		return cipher.decrypt_and_verify(ciphertext, tag).decode()
+
+	def _hash(self, plain: str) -> str:
+		return hmac.new(self._aes_key(), plain.encode(), hashlib.sha256).hexdigest()
+
+	def _envelope(self, body: dict, lower: bool) -> dict:
+		plain = json.dumps(body, separators=(",", ":"))
+		msg_key, hash_key = ("requestMsg", "requestHash") if lower else ("RequestMsg", "RequestHash")
+		return {msg_key: self._encrypt(plain), hash_key: self._hash(plain)}

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
@@ -11,6 +11,7 @@ import frappe
 import requests
 from Crypto.Cipher import AES
 from frappe import _
+from frappe.utils import flt
 
 from india_banking_connector.connectors.bank_connector import BankConnector
 from india_banking_connector.india_banking_connector.doctype.bank_request_log.bank_request_log import (
@@ -18,10 +19,16 @@ from india_banking_connector.india_banking_connector.doctype.bank_request_log.ba
 )
 
 GCM_TAG_LENGTH = 16
+
+# Batch-level ack code, shared by TransactionPosting and BeneficiaryRequest
+# responses. R000=Batch Received, R001=validation error (duplicate/invalid
+# count/amount), R004=invalid request/hash, R005=internal server error - any
+# non-R000 is surfaced as a failure via StatusDesc, so they don't need their
+# own branches.
 POSTING_ACCEPTED_CODE = "R000"
 
-# Mode of Transfer -> IndusInd tranType. IFTO (Internal/A2A) addresses the
-# beneficiary by IblAcctNo instead of IFSC + account number.
+# Mode of Transfer -> IndusInd tranType. IFTO (Internal/A2A) is a within-bank
+# transfer, so benIFSC is sent empty for it; benAcctNo is always populated.
 TRAN_TYPE = {
 	"imps": "IMPS",
 	"neft": "NEFT",
@@ -29,22 +36,30 @@ TRAN_TYPE = {
 	"a2a": "IFTO",
 }
 
-# IndusInd TransactionEnquiry StatusCode -> Payment Order Summary payment_status.
-# SP/UP/N/P/PR/FA/SW are deliberately non-final (mapped to Pending): re-initiating
-# on these causes double payments. J/F vs R/RE -> Failed/Rejected is a judgment
-# call pending bank confirmation (the H2H doc groups all four as one bucket).
+# IndusInd "Status Maintained for APIs" (H2H doc) -> Payment Order Summary
+# payment_status. SP/UP/N-P/PR/FA/SW are deliberately non-final (mapped to
+# Pending): re-initiating on these causes double payments.
 STATUS = {
-	"S": "Processed",
-	"UP": "Pending",
-	"N/P": "Pending",
-	"PR": "Pending",
-	"SP": "Pending",
-	"FA": "Pending",
-	"SW": "Pending",
-	"J": "Failed",
-	"F": "Failed",
+	"S": "Processed",  # Success
+	"UP": "Pending",  # Authorized/Under Processing
+	"N/P": "Pending",  # Pending for Authorization
+	"PR": "Pending",  # Pending for Release
+	"SP": "Pending",  # Suspect Time-out
+	"FA": "Pending",  # Future dated Transaction
+	"SW": "Pending",  # Scheduled for Next Applicable Day
+	"J": "Failed",  # Expired / Front end validation failure
+	"F": "Failed",  # Failure (Finacle / IMPS Hub)
+	"RE": "Failed",  # Return (processed, then bounced back)
+	"R": "Rejected",  # Rejected
+}
+
+# IndusInd Beneficiary "Status Maintained for APIs" (H2H Beneficiary doc).
+BENEFICIARY_STATUS = {
+	"A": "Active",
+	"I": "Inactive",
 	"R": "Rejected",
-	"RE": "Rejected",
+	"J": "Failed",
+	"H": "Pending",  # account validation in process
 }
 
 
@@ -53,8 +68,10 @@ class IndusIndBankConnector(BankConnector):
 
 	# IndusInd's Batch API uses AES-256-GCM + HMAC-SHA256, which the base class
 	# doesn't provide (it only has CBC and JWE-wrapped GCM). Byte layout below
-	# (ciphertext|tag, fixed IV from the `iv` field) is per the H2H doc and is
-	# unverified against a live UAT sample — confirm before a real UAT call.
+	# (ciphertext|tag, fixed IV from the `iv` field) confirmed against a live
+	# UAT TransactionPosting round trip on 2026-06-26 (decrypted a real R005
+	# response cleanly) - this was wrong until aes_key/iv were set to the
+	# bank-issued values instead of the test-fixture placeholders.
 
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
@@ -66,6 +83,12 @@ class IndusIndBankConnector(BankConnector):
 
 	def _aes_iv(self) -> bytes:
 		return bytes.fromhex(self.get_password("iv"))
+
+	def _hash_key(self) -> bytes:
+		# The bank HMACs with the 64-char hex key string taken as literal ASCII
+		# bytes, not the 32 raw bytes it decodes to for AES - confirmed by
+		# matching their responseHash on a live UAT call (2026-06-27).
+		return self.get_password("aes_key").encode()
 
 	def _encrypt(self, plain: str) -> str:
 		cipher = AES.new(self._aes_key(), AES.MODE_GCM, nonce=self._aes_iv())
@@ -79,7 +102,7 @@ class IndusIndBankConnector(BankConnector):
 		return cipher.decrypt_and_verify(ciphertext, tag).decode()
 
 	def _hash(self, plain: str) -> str:
-		return hmac.new(self._aes_key(), plain.encode(), hashlib.sha256).hexdigest()
+		return b64encode(hmac.new(self._hash_key(), plain.encode(), hashlib.sha256).digest()).decode()
 
 	def _envelope(self, body: dict, lower: bool) -> dict:
 		plain = json.dumps(body, separators=(",", ":"))
@@ -101,7 +124,7 @@ class IndusIndBankConnector(BankConnector):
 		if existing := self.validate_duplicate_payments(unique_id=unique_id):
 			return existing
 
-		payload = self.get_encrypted_payload("make_payment")
+		payload = self.get_encrypted_payload("make_payment", lower=True)
 		response = requests.post(self.urls.make_payment, headers=self.headers, json=payload)
 
 		log_id = create_api_log(
@@ -116,7 +139,9 @@ class IndusIndBankConnector(BankConnector):
 		return self.get_decrypted_response(response, method="make_payment", log_id=log_id)
 
 	def get_payment_status(self):
-		payload = self.get_encrypted_payload("payment_status")
+		# Per the H2H doc, TransactionEnquiry's envelope is RequestMsg/RequestHash
+		# (uppercase) - TransactionPosting is the only lowercase one.
+		payload = self.get_encrypted_payload("payment_status", lower=False)
 		response = requests.post(self.urls.payment_status, headers=self.headers, json=payload)
 
 		log_id = create_api_log(
@@ -136,26 +161,73 @@ class IndusIndBankConnector(BankConnector):
 	def get_bank_statement(self):
 		frappe.throw(_("Not supported by IndusInd Batch API"))
 
+	@frappe.whitelist()
+	def add_beneficiaries(self, beneficiaries, batch_id=None):
+		"""beneficiaries: list of dicts with ben_code, tran_type, ben_name, ben_ifsc,
+		ben_acct_no, ibl_acct_no, ben_email, ben_mobile, req_mode (default "A")."""
+		if isinstance(beneficiaries, str):
+			beneficiaries = json.loads(beneficiaries)
+
+		self._beneficiaries = beneficiaries
+		self._beneficiary_batch_id = batch_id or frappe.generate_hash(length=10)
+
+		payload = self.get_encrypted_payload("beneficiary_request", lower=False)
+		response = requests.post(self.urls.beneficiary_request, headers=self.headers, json=payload)
+
+		log_id = create_api_log(
+			response,
+			action="Add Beneficiaries",
+			account_config=self.account_config,
+			ref_doctype=self.doctype,
+			ref_docname=self.name,
+			unique_id=self._beneficiary_batch_id,
+			connector=self,
+		)
+		return self.get_decrypted_response(response, method="beneficiary_request", log_id=log_id)
+
+	@frappe.whitelist()
+	def get_beneficiary_status(self, ref_no):
+		self._beneficiary_ref_no = ref_no
+
+		payload = self.get_encrypted_payload("beneficiary_enquiry", lower=False)
+		response = requests.post(self.urls.beneficiary_enquiry, headers=self.headers, json=payload)
+
+		log_id = create_api_log(
+			response,
+			action="Beneficiary Status",
+			account_config=self.account_config,
+			ref_doctype=self.doctype,
+			ref_docname=self.name,
+			unique_id=ref_no,
+			connector=self,
+		)
+		return self.get_decrypted_response(response, method="beneficiary_enquiry", log_id=log_id)
+
 	# ---- payload builders ----
 
-	def get_encrypted_payload(self, method):
+	def get_encrypted_payload(self, method, lower):
 		self.update_account_config(method)
-		return self._envelope(self.account_config["body"], lower=True)
+		return self._envelope(self.account_config["body"], lower=lower)
 
 	def update_account_config(self, method):
 		{
 			"make_payment": self.set_payment_data,
 			"payment_status": self.set_payment_status_data,
+			"beneficiary_request": self.set_beneficiary_request_data,
+			"beneficiary_enquiry": self.set_beneficiary_enquiry_data,
 		}[method]()
 
 	def set_payment_data(self):
 		summary = self.doc.get("summary") or []
+		# batchAmount must equal the sum of the payments below - self.doc.get("total")
+		# isn't reliable (it was "0.0" against a real 1000.0 payment in UAT testing).
+		batch_amount = sum(flt(row.get("amount")) for row in summary)
 		self.account_config["body"] = {
 			"multiPayReq": {
 				"header": {
 					"batchId": self._unique_id(),
 					"batchCount": str(len(summary)),
-					"batchAmount": str(self.doc.get("total")),
+					"batchAmount": str(batch_amount),
 					"makerId": self.maker_id,
 					"checkerId": self.checker_id,
 					"payMode": self.pay_mode or "I",
@@ -170,19 +242,27 @@ class IndusIndBankConnector(BankConnector):
 		row = frappe._dict(row)
 		tran_type = self._tran_type(row.mode_of_transfer)
 
-		payment = {
+		return {
 			"tranType": tran_type,
 			"custRefNo": row.name,
 			"amount": row.amount,
 			"debitAcctNo": self.account_number,
+			"valueDate": "",
+			"benCode": "",
 			"benName": self.clean_string(row.party_name or row.party),
+			"benIFSC": "" if tran_type == "IFTO" else (row.branch_code or ""),
+			"benAcctNo": row.bank_account_no or "",
+			"benEmail": row.email or "",
+			"benMobile": self._ben_mobile(row),
+			"reserve1": "",
+			"reserve2": "",
+			"reserve3": "",
 		}
-		if tran_type == "IFTO":
-			payment["IblAcctNo"] = row.bank_account_no
-		else:
-			payment["benIFSC"] = row.branch_code
-			payment["benAcctNo"] = row.bank_account_no
-		return payment
+
+	def _ben_mobile(self, row):
+		if not (row.party_type and row.party):
+			return ""
+		return frappe.db.get_value(row.party_type, row.party, "mobile_no") or ""
 
 	def _tran_type(self, mode_of_transfer):
 		mode = (mode_of_transfer or "").lower()
@@ -195,6 +275,49 @@ class IndusIndBankConnector(BankConnector):
 		self.account_config["body"] = {
 			"Customerid": self.customer_id,
 			"RefNo": self._unique_id(),
+			"IsBatch": "Y",
+		}
+
+	def set_beneficiary_request_data(self):
+		beneficiaries = self._beneficiaries
+		self.account_config["body"] = {
+			"MultiBeneReq": {
+				"Header": {
+					"BatchId": self._beneficiary_batch_id,
+					"BatchCount": str(len(beneficiaries)),
+					"MakerId": self.maker_id,
+					"CheckerId": self.checker_id,
+					"CustId": self.customer_id,
+				},
+				"Body": {"BeneList": [self._beneficiary_row(b) for b in beneficiaries]},
+			}
+		}
+
+	def _beneficiary_row(self, beneficiary):
+		beneficiary = frappe._dict(beneficiary)
+		tran_type = beneficiary.tran_type
+		if isinstance(tran_type, list):
+			tran_type = ",".join(tran_type)
+
+		return {
+			"ReqMode": beneficiary.req_mode or "A",
+			"TranType": tran_type or "",
+			"BenCode": beneficiary.ben_code or "",
+			"BenName": self.clean_string(beneficiary.ben_name),
+			"BenIFSC": beneficiary.ben_ifsc or "",
+			"BenAcctNo": beneficiary.ben_acct_no or "",
+			"IblAcctNo": beneficiary.ibl_acct_no or "",
+			"BenEmail": beneficiary.ben_email or "",
+			"BenMobile": beneficiary.ben_mobile or "",
+			"Reserve1": "",
+			"Reserve2": "",
+			"Reserve3": "",
+		}
+
+	def set_beneficiary_enquiry_data(self):
+		self.account_config["body"] = {
+			"Customerid": self.customer_id,
+			"RefNo": self._beneficiary_ref_no,
 			"IsBatch": "Y",
 		}
 
@@ -211,6 +334,22 @@ class IndusIndBankConnector(BankConnector):
 			return res
 
 		data = response.json()
+		enc_key = "responseMsg" if "responseMsg" in data else "ResponseMsg" if "ResponseMsg" in data else None
+		if enc_key:
+			# Confirmed against live UAT (2026-06-20): IndusInd encrypts responses
+			# too, contradicting the H2H doc's plaintext response samples. Byte
+			# layout/key for decryption confirmed 2026-06-26 - same AES-256-GCM
+			# layout as the request, same key/iv. The earlier "unconfirmed"
+			# failures were caused by aes_key/iv still holding test-fixture
+			# values instead of the bank-issued UAT key.
+			try:
+				data = json.loads(self._decrypt(data[enc_key]))
+			except Exception:
+				res.status = "Request Failure"
+				res.message = "Response Decryption Failed - confirm responseMsg byte layout with IndusInd."
+				self.set_decrypted_response(log_id, json.dumps(data))
+				return res
+
 		self.set_decrypted_response(log_id, json.dumps(data))
 		self.get_formated_response(data, res, method)
 		return res
@@ -219,10 +358,12 @@ class IndusIndBankConnector(BankConnector):
 		if isinstance(data, str):
 			data = json.loads(data)
 
-		if method == "make_payment":
-			self._format_payment_response(data, res)
-		elif method == "payment_status":
-			self._format_payment_status_response(data, res)
+		{
+			"make_payment": self._format_payment_response,
+			"payment_status": self._format_payment_status_response,
+			"beneficiary_request": self._format_beneficiary_request_response,
+			"beneficiary_enquiry": self._format_beneficiary_enquiry_response,
+		}[method](data, res)
 
 	def _format_payment_response(self, data, res):
 		accepted = data.get("StatusCode") == POSTING_ACCEPTED_CODE
@@ -243,4 +384,20 @@ class IndusIndBankConnector(BankConnector):
 				"message": txn.get("StatusDesc", ""),
 			}
 			for txn in transactions
+		}
+
+	def _format_beneficiary_request_response(self, data, res):
+		accepted = data.get("StatusCode") == POSTING_ACCEPTED_CODE
+		res.status = "Accepted" if accepted else "Failed"
+		res.message = data.get("StatusDesc", "")
+
+	def _format_beneficiary_enquiry_response(self, data, res):
+		beneficiaries = data.get("BeneResp", {}).get("BeneList", [])
+		res.status = "Fetched" if beneficiaries else "Request Failure"
+		res.beneficiaries = {
+			bene.get("BenCode"): {
+				"status": BENEFICIARY_STATUS.get(bene.get("StatusCode"), bene.get("StatusCode", "")),
+				"message": bene.get("StatusDesc", ""),
+			}
+			for bene in beneficiaries
 		}

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
@@ -255,7 +255,7 @@ class IndusIndBankConnector(BankConnector):
 			"amount": row.amount,
 			"debitAcctNo": self.account_number,
 			"valueDate": "",
-			"benCode": "",
+			"benCode": self._ben_code(row),
 			"benName": self.clean_string(row.party_name or row.party),
 			"benIFSC": "" if tran_type == "IFTO" else (row.branch_code or ""),
 			"benAcctNo": row.bank_account_no or "",
@@ -265,6 +265,11 @@ class IndusIndBankConnector(BankConnector):
 			"reserve2": "",
 			"reserve3": "",
 		}
+
+	def _ben_code(self, row):
+		if not row.bank_account:
+			return ""
+		return frappe.db.get_value("Bank Account", row.bank_account, "indusind_ben_code") or ""
 
 	def _ben_mobile(self, row):
 		if not (row.party_type and row.party):
@@ -413,3 +418,97 @@ class IndusIndBankConnector(BankConnector):
 			}
 			for bene in beneficiaries
 		}
+
+
+# ---- Bank Account beneficiary registration ----
+# Surfaces add_beneficiaries/get_beneficiary_status - which are IndusInd-only
+# concepts (HDFC/ICICI take beneficiary details ad-hoc, per payment, with no
+# registration step) - as actions on a supplier's Bank Account, since that's
+# the natural place beneficiary details live.
+
+ALL_TRAN_TYPES = "IMPS,NEFT,RTGS"
+
+
+def get_default_indusind_connector():
+	connectors = frappe.get_all("IndusInd Bank Connector", pluck="name")
+	if not connectors:
+		frappe.throw(_("No IndusInd Bank Connector is configured."))
+	if len(connectors) > 1:
+		frappe.throw(
+			_("Multiple IndusInd Bank Connectors found - please specify which one to use.")
+		)
+	return connectors[0]
+
+
+@frappe.whitelist()
+def get_indusind_connectors():
+	return frappe.get_all("IndusInd Bank Connector", pluck="name")
+
+
+@frappe.whitelist()
+def add_beneficiary_for_bank_account(bank_account, connector=None):
+	ba = frappe.get_doc("Bank Account", bank_account)
+	conn = frappe.get_doc(
+		"IndusInd Bank Connector", connector or get_default_indusind_connector()
+	)
+
+	ben_code = ba.get("indusind_ben_code") or frappe.generate_hash(length=8).upper()
+	batch_id = frappe.generate_hash(length=10)
+
+	beneficiary = {
+		"req_mode": "A",
+		"ben_code": ben_code,
+		"ben_name": ba.account_name,
+		"ben_email": ba.email,
+		"ben_mobile": ba.mobile_number,
+	}
+	# Two mutually exclusive shapes per the bank's own sample payloads
+	# (test_beneficiary_request_matches_bank_sample_shape): a same-bank
+	# beneficiary uses "IFTO" + IblAcctNo only; everyone else uses the rail
+	# list + BenIFSC/BenAcctNo, with IblAcctNo left empty. Sending both
+	# (as this used to) gets rejected with "Invalid IFT Transaction Type".
+	if ba.bank == conn.bank:
+		beneficiary["tran_type"] = "IFTO"
+		beneficiary["ibl_acct_no"] = ba.bank_account_no
+	else:
+		beneficiary["tran_type"] = ALL_TRAN_TYPES
+		beneficiary["ben_ifsc"] = ba.branch_code
+		beneficiary["ben_acct_no"] = ba.bank_account_no
+
+	res = conn.add_beneficiaries([beneficiary], batch_id=batch_id)
+
+	frappe.db.set_value(
+		"Bank Account",
+		bank_account,
+		{
+			"indusind_ben_code": ben_code,
+			"indusind_beneficiary_batch_id": batch_id,
+			"indusind_beneficiary_status": "Pending" if res.status == "Accepted" else "Rejected",
+			"indusind_beneficiary_message": res.message or "",
+		},
+	)
+	return res
+
+
+@frappe.whitelist()
+def check_beneficiary_status_for_bank_account(bank_account, connector=None):
+	ba = frappe.get_doc("Bank Account", bank_account)
+	batch_id = ba.get("indusind_beneficiary_batch_id")
+	if not batch_id:
+		frappe.throw(_("This Bank Account has not been registered as a beneficiary yet."))
+
+	conn = frappe.get_doc(
+		"IndusInd Bank Connector", connector or get_default_indusind_connector()
+	)
+	res = conn.get_beneficiary_status(ref_no=batch_id)
+
+	details = frappe._dict((res.beneficiaries or {}).get(ba.indusind_ben_code, {}))
+	frappe.db.set_value(
+		"Bank Account",
+		bank_account,
+		{
+			"indusind_beneficiary_status": details.get("status") or "Pending",
+			"indusind_beneficiary_message": details.get("message", ""),
+		},
+	)
+	return res

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
@@ -272,9 +272,13 @@ class IndusIndBankConnector(BankConnector):
 		return "NEFT"
 
 	def set_payment_status_data(self):
+		# RefNo must be the bank-assigned BatchRefNo from the initiate-payment
+		# ack, not our own batchId - IndusInd doesn't recognise the client's
+		# reference for TransactionEnquiry. Fall back to the old (incorrect)
+		# behaviour only for batches initiated before this field existed.
 		self.account_config["body"] = {
 			"Customerid": self.customer_id,
-			"RefNo": self._unique_id(),
+			"RefNo": self.doc.get("batch_ref_no") or self._unique_id(),
 			"IsBatch": "Y",
 		}
 
@@ -369,6 +373,7 @@ class IndusIndBankConnector(BankConnector):
 		accepted = data.get("StatusCode") == POSTING_ACCEPTED_CODE
 		res.payment_status = "ACCEPTED" if accepted else "FAILED"
 		res.message = data.get("StatusDesc", "")
+		res.batch_ref_no = data.get("BatchRefNo", "")
 		res.summary_details = self.get_summary_details("Accepted" if accepted else "Failed")
 
 	def _format_payment_status_response(self, data, res):

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/indusind_bank_connector.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aerele Technologies Private Limited and contributors
+# For license information, please see license.txt
+
+from india_banking_connector.connectors.bank_connector import BankConnector
+
+
+class IndusIndBankConnector(BankConnector):
+	bank = "IndusInd Bank"

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/test_indusind_bank_connector.py
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/test_indusind_bank_connector.py
@@ -5,20 +5,23 @@ import hashlib
 import hmac
 import json
 from base64 import b64decode, b64encode
+from unittest.mock import patch
 
 import frappe
+import requests
 from Crypto.Cipher import AES
 from frappe.tests.utils import FrappeTestCase
 
 AES_KEY_HEX = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
 AES_IV_HEX = "000102030405060708090a0b0c0d0e0f"
+TEST_ACCOUNT_NUMBER = "TESTACC001"
 
 
 def get_test_connector(**fields):
 	return frappe.get_doc(
 		{
 			"doctype": "IndusInd Bank Connector",
-			"account_number": "TESTACC001",
+			"account_number": TEST_ACCOUNT_NUMBER,
 			"customer_id": "CUST001",
 			"maker_id": "SMAKER",
 			"checker_id": "SCHECKER",
@@ -32,7 +35,29 @@ def get_test_connector(**fields):
 	)
 
 
-class TestIndusIndBankConnector(FrappeTestCase):
+def fake_response(body: dict, status_code: int = 200) -> requests.Response:
+	"""A real requests.Response (create_api_log requires isinstance(res, Response))."""
+	resp = requests.Response()
+	resp.status_code = status_code
+	resp._content = json.dumps(body).encode()
+	req = requests.PreparedRequest()
+	req.prepare(method="POST", url="https://uat.indusind.example/batch", headers={}, data="{}")
+	resp.request = req
+	return resp
+
+
+def payment_order(name, summary_rows):
+	return frappe._dict(
+		{
+			"doctype": "Payment Order",
+			"name": name,
+			"total": sum(row["amount"] for row in summary_rows),
+			"summary": [frappe._dict(row) for row in summary_rows],
+		}
+	)
+
+
+class TestIndusIndBankConnectorCrypto(FrappeTestCase):
 	def setUp(self):
 		self.connector = get_test_connector()
 
@@ -81,3 +106,144 @@ class TestIndusIndBankConnector(FrappeTestCase):
 		plain = json.dumps(body, separators=(",", ":"))
 		envelope = self.connector._envelope(body, lower=True)
 		self.assertEqual(envelope["requestHash"], self.connector._hash(plain))
+
+
+class TestIndusIndBankConnectorPayloadBuilders(FrappeTestCase):
+	def setUp(self):
+		self.connector = get_test_connector()
+		self.connector.account_number = TEST_ACCOUNT_NUMBER
+
+	def test_neft_row_uses_ifsc_and_account_number(self):
+		row = self.connector._payment_row(
+			{"name": "POS-1", "amount": 100, "mode_of_transfer": "NEFT", "branch_code": "INDB0000123", "bank_account_no": "111", "party_name": "Vendor A"}
+		)
+		self.assertEqual(row["tranType"], "NEFT")
+		self.assertEqual(row["benIFSC"], "INDB0000123")
+		self.assertEqual(row["benAcctNo"], "111")
+		self.assertNotIn("IblAcctNo", row)
+
+	def test_a2a_row_uses_iblacctno_not_ifsc(self):
+		row = self.connector._payment_row(
+			{"name": "POS-2", "amount": 200, "mode_of_transfer": "A2A/FT/Internal", "branch_code": "IGNORED", "bank_account_no": "222", "party_name": "Vendor B"}
+		)
+		self.assertEqual(row["tranType"], "IFTO")
+		self.assertEqual(row["IblAcctNo"], "222")
+		self.assertNotIn("benIFSC", row)
+		self.assertNotIn("benAcctNo", row)
+
+	def test_unknown_mode_defaults_to_neft(self):
+		self.assertEqual(self.connector._tran_type("Cheque"), "NEFT")
+
+	def test_format_payment_response_accepted(self):
+		self.connector.doc = payment_order("PO-1", [{"name": "POS-1", "amount": 1}])
+		res = frappe._dict()
+		self.connector._format_payment_response(
+			{"StatusCode": "R000", "StatusDesc": "Batch Received"}, res
+		)
+		self.assertEqual(res.payment_status, "ACCEPTED")
+		self.assertEqual(res.summary_details, {"POS-1": {"payment_status": "Accepted"}})
+
+	def test_format_payment_response_rejected(self):
+		self.connector.doc = payment_order("PO-2", [{"name": "POS-2", "amount": 1}])
+		res = frappe._dict()
+		self.connector._format_payment_response(
+			{"StatusCode": "R001", "StatusDesc": "Invalid Batch"}, res
+		)
+		self.assertEqual(res.payment_status, "FAILED")
+		self.assertEqual(res.summary_details, {"POS-2": {"payment_status": "Failed"}})
+
+	def test_format_payment_status_response_maps_codes(self):
+		res = frappe._dict()
+		self.connector._format_payment_status_response(
+			{
+				"PayResp": {
+					"Transaction": [
+						{"CustRefNo": "POS-1", "StatusCode": "S", "StatusDesc": "Success", "UTR": "UTR1"},
+						{"CustRefNo": "POS-2", "StatusCode": "SP", "StatusDesc": "Suspect"},
+						{"CustRefNo": "POS-3", "StatusCode": "R", "StatusDesc": "Rejected by bank"},
+					]
+				}
+			},
+			res,
+		)
+		self.assertEqual(res.payment_status, "PROCESSED")
+		self.assertEqual(res.summary_details["POS-1"], {"status": "Processed", "utr_number": "UTR1", "message": "Success"})
+		self.assertEqual(res.summary_details["POS-2"]["status"], "Pending")
+		self.assertEqual(res.summary_details["POS-3"]["status"], "Rejected")
+
+
+class TestIndusIndBankConnectorOperations(FrappeTestCase):
+	def setUp(self):
+		frappe.db.delete("IndusInd Bank Connector", {"account_number": TEST_ACCOUNT_NUMBER})
+		self.connector = get_test_connector()
+		self.connector.insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.db.delete("Bank Request Log", {"connector_name": self.connector.name})
+		frappe.delete_doc("IndusInd Bank Connector", self.connector.name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_initiate_payment_sends_gcm_envelope_and_maps_accepted_response(self):
+		self.connector.doc = payment_order(
+			"PO-INIT-1",
+			[{"name": "POS-INIT-1", "amount": 250, "mode_of_transfer": "NEFT", "branch_code": "INDB0000123", "bank_account_no": "111", "party_name": "Vendor A"}],
+		)
+		ack = {"BatchRefNo": "BR1", "TxnCount": "1", "StatusCode": "R000", "StatusDesc": "Batch Received"}
+
+		with patch("requests.post", return_value=fake_response(ack)) as mock_post:
+			result = self.connector.initiate_payment()
+
+		sent_payload = mock_post.call_args.kwargs["json"]
+		self.assertEqual(set(sent_payload.keys()), {"requestMsg", "requestHash"})
+		decrypted = json.loads(self.connector._decrypt(sent_payload["requestMsg"]))
+		self.assertEqual(
+			decrypted["multiPayReq"]["body"]["payment"][0]["custRefNo"], "POS-INIT-1"
+		)
+		self.assertEqual(result.payment_status, "ACCEPTED")
+		self.assertEqual(result.summary_details, {"POS-INIT-1": {"payment_status": "Accepted"}})
+
+	def test_initiate_payment_dedupes_on_retry_without_second_http_call(self):
+		self.connector.doc = payment_order(
+			"PO-INIT-2",
+			[{"name": "POS-INIT-2", "amount": 100, "mode_of_transfer": "IMPS", "branch_code": "INDB0000999", "bank_account_no": "222", "party_name": "Vendor B"}],
+		)
+		ack = {"BatchRefNo": "BR2", "TxnCount": "1", "StatusCode": "R000", "StatusDesc": "Batch Received"}
+
+		with patch("requests.post", return_value=fake_response(ack)) as mock_post:
+			self.connector.initiate_payment()
+			self.assertEqual(mock_post.call_count, 1)
+
+		retry_connector = frappe.get_doc("IndusInd Bank Connector", self.connector.name)
+		retry_connector.doc = self.connector.doc
+		with patch("requests.post", return_value=fake_response(ack)) as mock_post_retry:
+			retry_connector.initiate_payment()
+			self.assertEqual(mock_post_retry.call_count, 0)
+
+	def test_get_payment_status_round_trips_through_real_http_mock(self):
+		self.connector.doc = payment_order(
+			"PO-STATUS-1",
+			[{"name": "POS-STATUS-1", "amount": 100, "mode_of_transfer": "NEFT", "branch_code": "INDB0000123", "bank_account_no": "111", "party_name": "Vendor A"}],
+		)
+		status_body = {
+			"PayResp": {
+				"Transaction": [
+					{"CustRefNo": "POS-STATUS-1", "StatusCode": "S", "StatusDesc": "Success", "UTR": "UTR123"}
+				]
+			}
+		}
+
+		with patch("requests.post", return_value=fake_response(status_body)):
+			result = self.connector.get_payment_status()
+
+		self.assertEqual(result.payment_status, "PROCESSED")
+		self.assertEqual(
+			result.summary_details["POS-STATUS-1"],
+			{"status": "Processed", "utr_number": "UTR123", "message": "Success"},
+		)
+
+	def test_get_bank_balance_and_statement_are_unsupported(self):
+		with self.assertRaises(frappe.ValidationError):
+			self.connector.get_bank_balance()
+		with self.assertRaises(frappe.ValidationError):
+			self.connector.get_bank_statement()

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/test_indusind_bank_connector.py
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/test_indusind_bank_connector.py
@@ -1,9 +1,83 @@
 # Copyright (c) 2026, Aerele Technologies Private Limited and Contributors
 # See license.txt
 
-# import frappe
+import hashlib
+import hmac
+import json
+from base64 import b64decode, b64encode
+
+import frappe
+from Crypto.Cipher import AES
 from frappe.tests.utils import FrappeTestCase
+
+AES_KEY_HEX = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+AES_IV_HEX = "000102030405060708090a0b0c0d0e0f"
+
+
+def get_test_connector(**fields):
+	return frappe.get_doc(
+		{
+			"doctype": "IndusInd Bank Connector",
+			"account_number": "TESTACC001",
+			"customer_id": "CUST001",
+			"maker_id": "SMAKER",
+			"checker_id": "SCHECKER",
+			"client_id": "test-client-id",
+			"client_secret": "test-client-secret",
+			"aes_key": AES_KEY_HEX,
+			"iv": AES_IV_HEX,
+			"base_url": "https://uat.indusind.example",
+			**fields,
+		}
+	)
 
 
 class TestIndusIndBankConnector(FrappeTestCase):
-	pass
+	def setUp(self):
+		self.connector = get_test_connector()
+
+	def test_encrypt_decrypt_round_trip(self):
+		plain = json.dumps({"Customerid": "CUST001", "RefNo": "ABC123", "IsBatch": "Y"})
+		encrypted = self.connector._encrypt(plain)
+		self.assertEqual(self.connector._decrypt(encrypted), plain)
+
+	def test_encrypt_byte_layout_is_ciphertext_then_tag(self):
+		plain = "indusind-gcm-fixture"
+		encrypted = self.connector._encrypt(plain)
+
+		key = bytes.fromhex(AES_KEY_HEX)
+		iv = bytes.fromhex(AES_IV_HEX)
+		cipher = AES.new(key, AES.MODE_GCM, nonce=iv)
+		expected_ciphertext, expected_tag = cipher.encrypt_and_digest(plain.encode())
+
+		raw = b64decode(encrypted)
+		self.assertEqual(raw[:-16], expected_ciphertext)
+		self.assertEqual(raw[-16:], expected_tag)
+		self.assertEqual(encrypted, b64encode(expected_ciphertext + expected_tag).decode())
+
+	def test_decrypt_rejects_tampered_ciphertext(self):
+		encrypted = self.connector._encrypt("indusind-gcm-fixture")
+		raw = bytearray(b64decode(encrypted))
+		raw[0] ^= 0xFF
+		tampered = b64encode(bytes(raw)).decode()
+		with self.assertRaises(ValueError):
+			self.connector._decrypt(tampered)
+
+	def test_hash_matches_hmac_sha256_of_plaintext(self):
+		plain = json.dumps({"a": 1}, separators=(",", ":"))
+		expected = hmac.new(bytes.fromhex(AES_KEY_HEX), plain.encode(), hashlib.sha256).hexdigest()
+		self.assertEqual(self.connector._hash(plain), expected)
+
+	def test_envelope_uses_lowercase_keys_for_posting(self):
+		envelope = self.connector._envelope({"a": 1}, lower=True)
+		self.assertEqual(set(envelope.keys()), {"requestMsg", "requestHash"})
+
+	def test_envelope_uses_uppercase_keys_for_beneficiary_endpoints(self):
+		envelope = self.connector._envelope({"a": 1}, lower=False)
+		self.assertEqual(set(envelope.keys()), {"RequestMsg", "RequestHash"})
+
+	def test_envelope_hash_matches_serialized_body(self):
+		body = {"b": 2, "a": 1}
+		plain = json.dumps(body, separators=(",", ":"))
+		envelope = self.connector._envelope(body, lower=True)
+		self.assertEqual(envelope["requestHash"], self.connector._hash(plain))

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/test_indusind_bank_connector.py
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/test_indusind_bank_connector.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Aerele Technologies Private Limited and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestIndusIndBankConnector(FrappeTestCase):
+	pass

--- a/india_banking_connector/connectors/doctype/indusind_bank_connector/test_indusind_bank_connector.py
+++ b/india_banking_connector/connectors/doctype/indusind_bank_connector/test_indusind_bank_connector.py
@@ -89,15 +89,20 @@ class TestIndusIndBankConnectorCrypto(FrappeTestCase):
 			self.connector._decrypt(tampered)
 
 	def test_hash_matches_hmac_sha256_of_plaintext(self):
+		# HMAC key is the 64-char hex key STRING as literal ASCII bytes (not the
+		# 32 raw bytes AES uses), and the digest is base64, not hex - per the
+		# bank's actual convention confirmed against a live UAT response.
 		plain = json.dumps({"a": 1}, separators=(",", ":"))
-		expected = hmac.new(bytes.fromhex(AES_KEY_HEX), plain.encode(), hashlib.sha256).hexdigest()
+		expected = b64encode(
+			hmac.new(AES_KEY_HEX.encode(), plain.encode(), hashlib.sha256).digest()
+		).decode()
 		self.assertEqual(self.connector._hash(plain), expected)
 
 	def test_envelope_uses_lowercase_keys_for_posting(self):
 		envelope = self.connector._envelope({"a": 1}, lower=True)
 		self.assertEqual(set(envelope.keys()), {"requestMsg", "requestHash"})
 
-	def test_envelope_uses_uppercase_keys_for_beneficiary_endpoints(self):
+	def test_envelope_uses_uppercase_keys_for_beneficiary_request(self):
 		envelope = self.connector._envelope({"a": 1}, lower=False)
 		self.assertEqual(set(envelope.keys()), {"RequestMsg", "RequestHash"})
 
@@ -120,16 +125,18 @@ class TestIndusIndBankConnectorPayloadBuilders(FrappeTestCase):
 		self.assertEqual(row["tranType"], "NEFT")
 		self.assertEqual(row["benIFSC"], "INDB0000123")
 		self.assertEqual(row["benAcctNo"], "111")
-		self.assertNotIn("IblAcctNo", row)
 
-	def test_a2a_row_uses_iblacctno_not_ifsc(self):
+	def test_a2a_row_blanks_ifsc_but_keeps_account_number(self):
+		# Per the bank's BatchPostingReqResp sample: IFTO sends benIFSC="" while
+		# benAcctNo stays populated. IblAcctNo only appears in beneficiary
+		# registration, never in the per-transaction payment row.
 		row = self.connector._payment_row(
 			{"name": "POS-2", "amount": 200, "mode_of_transfer": "A2A/FT/Internal", "branch_code": "IGNORED", "bank_account_no": "222", "party_name": "Vendor B"}
 		)
 		self.assertEqual(row["tranType"], "IFTO")
-		self.assertEqual(row["IblAcctNo"], "222")
-		self.assertNotIn("benIFSC", row)
-		self.assertNotIn("benAcctNo", row)
+		self.assertEqual(row["benIFSC"], "")
+		self.assertEqual(row["benAcctNo"], "222")
+		self.assertNotIn("IblAcctNo", row)
 
 	def test_unknown_mode_defaults_to_neft(self):
 		self.assertEqual(self.connector._tran_type("Cheque"), "NEFT")
@@ -170,6 +177,130 @@ class TestIndusIndBankConnectorPayloadBuilders(FrappeTestCase):
 		self.assertEqual(res.summary_details["POS-1"], {"status": "Processed", "utr_number": "UTR1", "message": "Success"})
 		self.assertEqual(res.summary_details["POS-2"]["status"], "Pending")
 		self.assertEqual(res.summary_details["POS-3"]["status"], "Rejected")
+
+
+class TestIndusIndBankConnectorAgainstRealUATSamples(FrappeTestCase):
+	"""Each test below is transcribed verbatim from the bank's UAT sample .txt files
+	(BatchPostingReqResp, BatchEnquiryReqRes, BeneAdditionRequestResponse,
+	BeneEnquiryRequestResponse) so a wire-format regression fails loudly."""
+
+	def setUp(self):
+		self.connector = get_test_connector()
+		self.connector.account_number = "200999514476"
+		self.connector.customer_id = "31202366"
+		self.connector.maker_id = "rakm"
+		self.connector.checker_id = "rakc1"
+
+	def test_transaction_posting_request_matches_bank_sample_shape(self):
+		self.connector.doc = payment_order(
+			"BATCH1404",
+			[
+				{"name": "0514973", "amount": 200, "mode_of_transfer": "IMPS", "branch_code": "SYNB0008538", "bank_account_no": "88888455", "party_name": "Amit Kumar"},
+				{"name": "0514988", "amount": 200, "mode_of_transfer": "NEFT", "branch_code": "SYNB0008538", "bank_account_no": "88888455", "party_name": "Amit Kumar"},
+				{"name": "0614004", "amount": 200, "mode_of_transfer": "A2A/FT/Internal", "branch_code": "SYNB0008538", "bank_account_no": "88888455", "party_name": "Amit Kumar"},
+			],
+		)
+		self.connector.update_account_config("make_payment")
+		body = self.connector.account_config["body"]["multiPayReq"]
+		payments = body["body"]["payment"]
+
+		# batchCount/batchAmount are sent as JSON strings ("3"/"600") in the
+		# sample, while each row's amount is a raw JSON number (200, not "200").
+		self.assertEqual(body["header"]["batchCount"], "3")
+		self.assertIsInstance(body["header"]["batchAmount"], str)
+		self.assertIsInstance(payments[0]["amount"], int)
+
+		self.assertEqual([p["tranType"] for p in payments], ["IMPS", "NEFT", "IFTO"])
+		self.assertEqual([p["custRefNo"] for p in payments], ["0514973", "0514988", "0614004"])
+		for p in payments:
+			self.assertEqual(p["benName"], "Amit Kumar")
+			self.assertEqual(p["benAcctNo"], "88888455")
+		self.assertEqual(payments[0]["benIFSC"], "SYNB0008538")
+		self.assertEqual(payments[2]["benIFSC"], "")  # IFTO: blank per sample
+
+	def test_transaction_posting_accepts_bank_sample_response(self):
+		ack = {"BatchRefNo": "DXK6040321066826", "TxnCount": "10", "StatusCode": "R000", "StatusDesc": "Batch Received"}
+		self.connector.doc = payment_order("BATCH1404", [{"name": "0514973", "amount": 200}])
+		res = frappe._dict()
+		self.connector._format_payment_response(ack, res)
+		self.assertEqual(res.payment_status, "ACCEPTED")
+		self.assertEqual(res.message, "Batch Received")
+
+	def test_transaction_enquiry_request_matches_bank_sample_shape(self):
+		self.connector.doc = payment_order("BAPI280421067549", [])
+		self.connector.update_account_config("payment_status")
+		self.assertEqual(
+			self.connector.account_config["body"],
+			{"Customerid": "31202366", "RefNo": "BAPI280421067549", "IsBatch": "Y"},
+		)
+
+	def test_transaction_enquiry_maps_bank_sample_response(self):
+		# Verbatim from BatchEnquiryReqRes.txt
+		sample_response = {
+			"PayResp": {
+				"Header": {"RefNo": "BAPI280421067549", "IsBatch": "Y", "TxnCount": "3", "Error": ""},
+				"Transaction": [
+					{"IBLRefNo": "DAL4280421000029", "CustRefNo": "0514973", "StatusCode": "UP", "StatusDesc": "Authorized/Under Processing", "UTR": "", "PaymentDate": "", "BeneficiaryName": ""},
+					{"IBLRefNo": "DAL4280421000030", "CustRefNo": "0514988", "StatusCode": "S", "StatusDesc": "Success", "UTR": "INDBN28044772077", "PaymentDate": "2021-04-28", "BeneficiaryName": ""},
+					{"IBLRefNo": "DAL4280421000031", "CustRefNo": "0614004", "StatusCode": "J", "StatusDesc": "Account does not exist", "UTR": "", "PaymentDate": "", "BeneficiaryName": ""},
+				],
+			}
+		}
+		res = frappe._dict()
+		self.connector._format_payment_status_response(sample_response, res)
+
+		self.assertEqual(res.summary_details["0514973"]["status"], "Pending")  # UP, never final
+		self.assertEqual(res.summary_details["0514988"], {"status": "Processed", "utr_number": "INDBN28044772077", "message": "Success"})
+		self.assertEqual(res.summary_details["0614004"], {"status": "Failed", "utr_number": "", "message": "Account does not exist"})
+
+	def test_beneficiary_request_matches_bank_sample_shape(self):
+		self.connector._beneficiaries = [
+			{"req_mode": "A", "tran_type": "IMPS,NEFT,RTGS", "ben_code": "BT752", "ben_name": "Amit Kumar", "ben_ifsc": "SYNB0008538", "ben_acct_no": "88888455", "ben_email": "amita.kumar@indusind.com", "ben_mobile": "639999512"},
+			{"req_mode": "A", "tran_type": "IFTO", "ben_code": "BN893", "ben_name": "Amit Kumar", "ibl_acct_no": "123456", "ben_email": "amita.kumar@indusind.com", "ben_mobile": "639999512"},
+		]
+		self.connector._beneficiary_batch_id = "BATCH897"
+		self.connector.update_account_config("beneficiary_request")
+
+		bene_list = self.connector.account_config["body"]["MultiBeneReq"]["Body"]["BeneList"]
+		self.assertEqual(bene_list[0]["TranType"], "IMPS,NEFT,RTGS")
+		self.assertEqual(bene_list[0]["BenIFSC"], "SYNB0008538")
+		self.assertEqual(bene_list[0]["BenAcctNo"], "88888455")
+		self.assertEqual(bene_list[0]["IblAcctNo"], "")
+
+		self.assertEqual(bene_list[1]["TranType"], "IFTO")
+		self.assertEqual(bene_list[1]["BenIFSC"], "")
+		self.assertEqual(bene_list[1]["BenAcctNo"], "")
+		self.assertEqual(bene_list[1]["IblAcctNo"], "123456")
+
+	def test_beneficiary_request_accepts_bank_sample_response(self):
+		ack = {"BatchRefNo": "A31O210521068040", "BeneCount": "2", "StatusCode": "R000", "StatusDesc": "Batch Received"}
+		res = frappe._dict()
+		self.connector._format_beneficiary_request_response(ack, res)
+		self.assertEqual(res.status, "Accepted")
+
+	def test_beneficiary_enquiry_request_matches_bank_sample_shape(self):
+		self.connector._beneficiary_ref_no = "A31O100521067968"
+		self.connector.customer_id = "32701183"
+		self.connector.update_account_config("beneficiary_enquiry")
+		self.assertEqual(
+			self.connector.account_config["body"],
+			{"Customerid": "32701183", "RefNo": "A31O100521067968", "IsBatch": "Y"},
+		)
+
+	def test_beneficiary_enquiry_maps_bank_sample_response(self):
+		# Verbatim from BeneEnquiryRequestResponse.txt
+		sample_response = {
+			"BeneResp": {
+				"Header": {"RefNo": "A31O100521067968", "IsBatch": "Y", "BeneCount": "1", "Error": ""},
+				"BeneList": [
+					{"BenCode": "BE118", "BenName": "Amit Kumar", "BenIFSC": "HDFC0000501", "BenAcctNo": "579625252415", "IblAcctNo": "", "StatusCode": "I", "StatusDesc": "InActive"}
+				],
+			}
+		}
+		res = frappe._dict()
+		self.connector._format_beneficiary_enquiry_response(sample_response, res)
+		self.assertEqual(res.status, "Fetched")
+		self.assertEqual(res.beneficiaries["BE118"], {"status": "Inactive", "message": "InActive"})
 
 
 class TestIndusIndBankConnectorOperations(FrappeTestCase):
@@ -233,14 +364,69 @@ class TestIndusIndBankConnectorOperations(FrappeTestCase):
 			}
 		}
 
-		with patch("requests.post", return_value=fake_response(status_body)):
+		with patch("requests.post", return_value=fake_response(status_body)) as mock_post:
 			result = self.connector.get_payment_status()
 
+		# Per the H2H doc, TransactionEnquiry uses RequestMsg/RequestHash
+		# (uppercase) unlike TransactionPosting.
+		self.assertEqual(set(mock_post.call_args.kwargs["json"].keys()), {"RequestMsg", "RequestHash"})
 		self.assertEqual(result.payment_status, "PROCESSED")
 		self.assertEqual(
 			result.summary_details["POS-STATUS-1"],
 			{"status": "Processed", "utr_number": "UTR123", "message": "Success"},
 		)
+
+	def test_get_payment_status_decrypts_encrypted_response(self):
+		# Confirmed against live UAT: IndusInd encrypts responses too, unlike
+		# the H2H doc's plaintext response samples.
+		self.connector.doc = payment_order(
+			"PO-STATUS-2",
+			[{"name": "POS-STATUS-2", "amount": 100, "mode_of_transfer": "NEFT", "branch_code": "INDB0000123", "bank_account_no": "111", "party_name": "Vendor A"}],
+		)
+		plain = json.dumps({"PayResp": {"Transaction": [{"CustRefNo": "POS-STATUS-2", "StatusCode": "S", "StatusDesc": "Success", "UTR": "UTR999"}]}})
+		encrypted_body = {"responseMsg": self.connector._encrypt(plain), "responseHash": self.connector._hash(plain)}
+
+		with patch("requests.post", return_value=fake_response(encrypted_body)):
+			result = self.connector.get_payment_status()
+
+		self.assertEqual(result.payment_status, "PROCESSED")
+		self.assertEqual(result.summary_details["POS-STATUS-2"]["utr_number"], "UTR999")
+
+	def test_get_payment_status_reports_failure_on_undecryptable_response(self):
+		self.connector.doc = payment_order("PO-STATUS-3", [{"name": "POS-STATUS-3", "amount": 100}])
+		bad_body = {"responseMsg": "not-valid-base64-gcm-ciphertext==", "responseHash": "irrelevant"}
+
+		with patch("requests.post", return_value=fake_response(bad_body)):
+			result = self.connector.get_payment_status()
+
+		self.assertEqual(result.status, "Request Failure")
+
+	def test_add_beneficiaries_sends_uppercase_envelope(self):
+		ack = {"BatchRefNo": "BR3", "BeneCount": "1", "StatusCode": "R000", "StatusDesc": "Batch Received"}
+		beneficiaries = [{"ben_code": "BT1", "tran_type": "NEFT", "ben_name": "Vendor A", "ben_ifsc": "INDB0000123", "ben_acct_no": "111"}]
+
+		with patch("requests.post", return_value=fake_response(ack)) as mock_post:
+			result = self.connector.add_beneficiaries(beneficiaries, batch_id="BATCH-TEST-1")
+
+		sent_payload = mock_post.call_args.kwargs["json"]
+		self.assertEqual(set(sent_payload.keys()), {"RequestMsg", "RequestHash"})
+		decrypted = json.loads(self.connector._decrypt(sent_payload["RequestMsg"]))
+		self.assertEqual(decrypted["MultiBeneReq"]["Header"]["BatchId"], "BATCH-TEST-1")
+		self.assertEqual(result.status, "Accepted")
+
+	def test_get_beneficiary_status_sends_uppercase_envelope(self):
+		status_body = {
+			"BeneResp": {
+				"BeneList": [{"BenCode": "BT1", "StatusCode": "A", "StatusDesc": "Active"}]
+			}
+		}
+
+		with patch("requests.post", return_value=fake_response(status_body)) as mock_post:
+			result = self.connector.get_beneficiary_status("REF-1")
+
+		sent_payload = mock_post.call_args.kwargs["json"]
+		self.assertEqual(set(sent_payload.keys()), {"RequestMsg", "RequestHash"})
+		self.assertEqual(result.beneficiaries["BT1"], {"status": "Active", "message": "Active"})
 
 	def test_get_bank_balance_and_statement_are_unsupported(self):
 		with self.assertRaises(frappe.ValidationError):

--- a/india_banking_connector/default.py
+++ b/india_banking_connector/default.py
@@ -9,6 +9,7 @@ STD_BANK_LIST = [
 	"IDFC First Bank",
 	"Canara Bank",
 	"CITI Bank",
+	"IndusInd Bank",
 ]
 
 DEFAULT_CONNECTOR = [
@@ -21,6 +22,7 @@ DEFAULT_CONNECTOR = [
 	"IDFC Connector",
 	"Axis Bank Connector",
 	"Canara Bank Connector",
+	"IndusInd Bank Connector",
 ]
 
 DEFAULT_HOSTS = [
@@ -39,6 +41,7 @@ BANKS_CONNECTOR_MAP = {
 	"IDFC Bank": "IDFC Connector",
 	"Axis Bank": "Axis Bank Connector",
 	"Canara Bank": "Canara Bank Connector",
+	"IndusInd Bank": "IndusInd Bank Connector",
 }
 
 BANKS_H2H_MAP = {

--- a/india_banking_connector/hooks.py
+++ b/india_banking_connector/hooks.py
@@ -9,6 +9,7 @@ after_install = "india_banking_connector.install.after_install"
 
 doctype_js = {
 	"Bank Account": "public/js/bank_account.js",
+	"Payment Order": "public/js/payment_order.js",
 }
 
 scheduler_events = {

--- a/india_banking_connector/hooks.py
+++ b/india_banking_connector/hooks.py
@@ -7,6 +7,10 @@ app_license = "mit"
 
 after_install = "india_banking_connector.install.after_install"
 
+doctype_js = {
+	"Bank Account": "public/js/bank_account.js",
+}
+
 scheduler_events = {
 	"cron": {
 		"*/5 * * * *": "india_banking_connector.tasks.fetch_payment_status",

--- a/india_banking_connector/install.py
+++ b/india_banking_connector/install.py
@@ -1,5 +1,6 @@
 import click
 import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 from india_banking_connector.default import (
 	BANKS_CONNECTOR_MAP,
@@ -14,6 +15,64 @@ def after_install():
 	create_bank_doctype()
 	create_default_bank()
 	create_connector_settings()
+	create_bank_account_beneficiary_fields()
+
+
+def create_bank_account_beneficiary_fields():
+	click.echo(" -> Installing IndusInd Beneficiary Fields in Bank Account")
+	create_custom_fields(
+		{
+			"Bank Account": [
+				{
+					"label": "IndusInd Beneficiary Details",
+					"fieldname": "indusind_beneficiary_section",
+					"fieldtype": "Section Break",
+					"insert_after": "bank_account_no",
+					"collapsible": 1,
+				},
+				{
+					"label": "Beneficiary Code",
+					"fieldname": "indusind_ben_code",
+					"fieldtype": "Data",
+					"read_only": 1,
+					"no_copy": 1,
+					"insert_after": "indusind_beneficiary_section",
+				},
+				{
+					"label": "Beneficiary Status",
+					"fieldname": "indusind_beneficiary_status",
+					"fieldtype": "Select",
+					"options": "\nNot Registered\nPending\nActive\nInactive\nRejected\nFailed",
+					"read_only": 1,
+					"no_copy": 1,
+					"insert_after": "indusind_ben_code",
+				},
+				{
+					"label": "",
+					"fieldname": "indusind_beneficiary_column_break",
+					"fieldtype": "Column Break",
+					"insert_after": "indusind_beneficiary_status",
+				},
+				{
+					"label": "Beneficiary Batch ID",
+					"fieldname": "indusind_beneficiary_batch_id",
+					"fieldtype": "Data",
+					"read_only": 1,
+					"no_copy": 1,
+					"hidden": 1,
+					"insert_after": "indusind_beneficiary_column_break",
+				},
+				{
+					"label": "Beneficiary Message",
+					"fieldname": "indusind_beneficiary_message",
+					"fieldtype": "Small Text",
+					"read_only": 1,
+					"no_copy": 1,
+					"insert_after": "indusind_beneficiary_batch_id",
+				},
+			],
+		}
+	)
 
 
 def create_default_bank():

--- a/india_banking_connector/patches.txt
+++ b/india_banking_connector/patches.txt
@@ -6,3 +6,4 @@ india_banking_connector.patches.v1_0.create_bank_doctype # apr29
 india_banking_connector.patches.v1_0.update_connector_settings #130026
 india_banking_connector.patches.v1_0.update_standard_banks #sep28
 india_banking_connector.patches.v16_0.update_api_endpoints #20250313 #9
+india_banking_connector.patches.v16_0.add_indusind_bank_connector #20260618

--- a/india_banking_connector/patches.txt
+++ b/india_banking_connector/patches.txt
@@ -7,3 +7,4 @@ india_banking_connector.patches.v1_0.update_connector_settings #130026
 india_banking_connector.patches.v1_0.update_standard_banks #sep28
 india_banking_connector.patches.v16_0.update_api_endpoints #20250313 #9
 india_banking_connector.patches.v16_0.add_indusind_bank_connector #20260618
+india_banking_connector.patches.v16_0.add_bank_account_beneficiary_fields #20260704

--- a/india_banking_connector/patches/v16_0/add_bank_account_beneficiary_fields.py
+++ b/india_banking_connector/patches/v16_0/add_bank_account_beneficiary_fields.py
@@ -1,0 +1,5 @@
+from india_banking_connector.install import create_bank_account_beneficiary_fields
+
+
+def execute():
+	create_bank_account_beneficiary_fields()

--- a/india_banking_connector/patches/v16_0/add_indusind_bank_connector.py
+++ b/india_banking_connector/patches/v16_0/add_indusind_bank_connector.py
@@ -1,0 +1,5 @@
+from india_banking_connector.install import create_connector_settings
+
+
+def execute():
+	create_connector_settings(update=True)

--- a/india_banking_connector/public/js/bank_account.js
+++ b/india_banking_connector/public/js/bank_account.js
@@ -1,0 +1,107 @@
+frappe.ui.form.on("Bank Account", {
+	refresh(frm) {
+		if (!(frm.doc.account_name && frm.doc.branch_code && frm.doc.bank_account_no)) return;
+
+		frappe.call({ method: "india_banking_connector.connectors.doctype.indusind_bank_connector.indusind_bank_connector.get_indusind_connectors" }).then((r) => {
+			const connectors = r.message || [];
+			if (!connectors.length) return;
+
+			const status = frm.doc.indusind_beneficiary_status;
+			const can_register = !frm.doc.indusind_beneficiary_batch_id || ["Failed", "Rejected"].includes(status);
+			const can_recheck = ["Pending", "Inactive"].includes(status);
+
+			if (can_register) {
+				frm.add_custom_button(__(frm.doc.indusind_beneficiary_batch_id ? "Retry Add Beneficiary" : "Add Beneficiary"), () => {
+					with_connector(connectors, (connector) => {
+						frappe.call({
+							method: "india_banking_connector.connectors.doctype.indusind_bank_connector.indusind_bank_connector.add_beneficiary_for_bank_account",
+							freeze: true,
+							freeze_message: __("Registering Beneficiary..."),
+							args: { bank_account: frm.doc.name, connector },
+							callback: (r) => {
+								show_result(__("Add Beneficiary"), r.message && r.message.status, r.message && r.message.message);
+								frm.reload_doc();
+							},
+						});
+					});
+				});
+			} else if (can_recheck) {
+				frm.add_custom_button(__("Check Beneficiary Status"), () => {
+					with_connector(connectors, (connector) => {
+						frappe.call({
+							method: "india_banking_connector.connectors.doctype.indusind_bank_connector.indusind_bank_connector.check_beneficiary_status_for_bank_account",
+							freeze: true,
+							freeze_message: __("Checking Beneficiary Status..."),
+							args: { bank_account: frm.doc.name, connector },
+							callback: () => {
+								frm.reload_doc().then(() => {
+									show_result(
+										__("Beneficiary Status"),
+										frm.doc.indusind_beneficiary_status,
+										frm.doc.indusind_beneficiary_message
+									);
+								});
+							},
+						});
+					});
+				});
+			}
+		});
+	},
+});
+
+// Inline hex rather than Frappe's named "indicator" classes - the shared
+// msgprint dialog's header indicator wasn't reliably reflecting the color
+// passed (seen rendering red for a "orange"-mapped status), so we render
+// our own badge instead of depending on that.
+const STATUS_COLOR = {
+	Active: "#2e7d32",
+	Accepted: "#2e7d32",
+	Pending: "#b45309",
+	Inactive: "#b45309",
+	Failed: "#c62828",
+	Rejected: "#c62828",
+};
+
+function show_result(title, status, message) {
+	const color = STATUS_COLOR[status] || "#555";
+	const status_text = status || __("Unknown");
+	const bank_message = message && message.trim().toLowerCase() !== status_text.trim().toLowerCase() ? message : null;
+
+	frappe.msgprint({
+		title,
+		message: `
+			<div>
+				<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${color};margin-right:6px;"></span>
+				${__("Status")}: <b>${frappe.utils.escape_html(status_text)}</b>
+				${bank_message ? `<div style="margin-top:6px;color:var(--text-muted);">${frappe.utils.escape_html(bank_message)}</div>` : ""}
+			</div>
+		`,
+	});
+}
+
+function with_connector(connectors, callback) {
+	if (connectors.length === 1) {
+		callback(connectors[0]);
+		return;
+	}
+
+	let dialog = new frappe.ui.Dialog({
+		title: __("Select IndusInd Bank Connector"),
+		fields: [
+			{
+				label: __("Connector"),
+				fieldname: "connector",
+				fieldtype: "Select",
+				options: connectors,
+				reqd: true,
+			},
+		],
+		primary_action_label: __("Proceed"),
+		primary_action(values) {
+			dialog.hide();
+			callback(values.connector);
+		},
+	});
+	dialog.show();
+}

--- a/india_banking_connector/public/js/payment_order.js
+++ b/india_banking_connector/public/js/payment_order.js
@@ -1,0 +1,76 @@
+// india_banking's own payment_order.js adds a plain "Get Status" button
+// that just reloads the form with no feedback. Rather than fork that file
+// (kept out of this app on purpose), rebind its click handler in place -
+// this app loads after india_banking (see installed_apps), so by the time
+// this refresh handler runs, india_banking's button already exists.
+// Removing + re-adding (frm.remove_custom_button + add_custom_button) would
+// instead append it at the end of the toolbar, after "Unlink Allocation" -
+// rebinding the existing element keeps its original position.
+frappe.ui.form.on("Payment Order", {
+	refresh(frm) {
+		if (!has_status_button(frm)) return;
+
+		const btn = frm.custom_buttons[__("Get Status")];
+		if (!btn) return;
+
+		btn.off("click").on("click", () => {
+			frappe.call({
+				method: "india_banking.india_banking.doctype.india_banking_connector.india_banking_connector.get_payment_status",
+				freeze: true,
+				freeze_message: __("Fetching payment status..."),
+				args: { payment_order: frm.doc.name },
+				callback: () => {
+					frm.reload_doc().then(() => show_payment_status_result(frm));
+				},
+			});
+		});
+	},
+});
+
+function has_status_button(frm) {
+	if (!(frm.doc.docstatus === 1 && frm.has_perm("write"))) return false;
+	return (frm.doc.summary || []).some(
+		(item) => item.payment_status === "Initiated" || item.payment_status !== "Pending"
+	);
+}
+
+const PAYMENT_STATUS_COLOR = {
+	Processed: "#2e7d32",
+	Approved: "#2e7d32",
+	Initiated: "#b45309",
+	Pending: "#b45309",
+	Failed: "#c62828",
+	Rejected: "#c62828",
+};
+
+function show_payment_status_result(frm) {
+	const rows = (frm.doc.summary || [])
+		.map((row) => {
+			const color = PAYMENT_STATUS_COLOR[row.payment_status] || "#555";
+			return `
+				<tr>
+					<td>${frappe.utils.escape_html(row.party || "")}</td>
+					<td>${frappe.utils.escape_html(cstr(row.amount))}</td>
+					<td>
+						<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${color};margin-right:6px;"></span>
+						${frappe.utils.escape_html(row.payment_status || "")}
+					</td>
+					<td>${frappe.utils.escape_html(row.message || "")}</td>
+				</tr>
+			`;
+		})
+		.join("");
+
+	frappe.msgprint({
+		title: __("Payment Status"),
+		wide: true,
+		message: `
+			<table class="table table-bordered" style="margin:0;">
+				<thead>
+					<tr><th>${__("Party")}</th><th>${__("Amount")}</th><th>${__("Status")}</th><th>${__("Message")}</th></tr>
+				</thead>
+				<tbody>${rows}</tbody>
+			</table>
+		`,
+	});
+}


### PR DESCRIPTION
# feat(connector): add IndusInd Bank Connector

## Summary

Adds a new **IndusInd Bank Connector** to `india_banking_connector`, enabling
API-based payouts, payment status enquiry, and beneficiary registration directly
from ERPNext against IndusInd's host-to-host (H2H) Batch API. This brings IndusInd
to parity with the existing ICICI / IDFC / Axis / Canara connectors.

## What's included

- **New `IndusInd Bank Connector` doctype** — connector config, endpoints, and credentials.
- **Crypto layer** — AES-256-GCM request/response encryption + HMAC-SHA256 signing,
  per IndusInd's H2H spec (the base class only provides CBC / JWE-wrapped GCM).
- **Payments** — `initiate_payment()` builds and posts the encrypted payment batch;
  **respects the user-selected Mode of Transfer** (IMPS / NEFT / RTGS), defaulting
  to **NEFT** when the mode is unmapped.
- **Payment status** — `get_payment_status()` enquiry keyed on the bank-assigned `BatchRefNo`.
- **Beneficiary management** — register beneficiaries on the Bank Account
  (`add_beneficiaries` / `get_beneficiary_status`) and reuse the returned `ben_code`
  in payments.
- **Registration & wiring** — added to `STD_BANK_LIST`, `DEFAULT_CONNECTOR`, and
  `BANKS_CONNECTOR_MAP`; new install setup, hooks, and two `v16_0` patches
  (connector registration + Bank Account beneficiary fields).
- **Client-side** — `bank_account.js` (beneficiary registration / status actions)
  and `payment_order.js` (status results shown without modifying `india_banking`).
- **Tests** — 29 unit tests covering crypto, payload building, and response formatting.

## Scope of change

- 13 files, +1,396 lines (net additive — no changes to other connectors).
- Base: `develop` · Branch: `feature/indusind-bank-connector` · 9 commits.

## ⚠️ Before merge — needs confirmation

- **Endpoints are currently UAT** (`indusapiuat.indusind.bank.in`). Confirm whether
  production URLs are config-driven or require a follow-up before this goes live.
- **Secrets** — verify no real AES/HMAC keys or client IDs are hardcoded in the
  doctype JSON or tests.

## Configuration / migration notes

- Run `bench migrate` to apply the two `v16_0` patches (registers the connector and
  adds beneficiary fields to Bank Account).
- Requires IndusInd H2H credentials (AES key/IV, HMAC key, client ID) configured on
  the connector record.

## Testing

> Note: run on a **dedicated fresh test site** — running against a data-filled dev
> site fails during test bootstrap (e.g. Fiscal Year overlap), not in the connector
> tests themselves.

```bash
bench new-site test_ibc.local --install-app india_banking_connector
bench --site test_ibc.local run-tests \
  --module india_banking_connector.connectors.doctype.indusind_bank_connector.test_indusind_bank_connector
```

- [ ] 29 unit tests pass on a fresh test site
- [ ] Beneficiary registration + status verified against IndusInd **UAT**
- [ ] End-to-end payout (NEFT / IMPS / RTGS) verified against **UAT**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IndusInd Bank integration for payment initiation and status tracking.
  * Added beneficiary registration and status-checking workflows from Bank Account records.
  * Added configurable connector settings for credentials, payment modes, testing, activation, and API endpoints.
  * Added Payment Order status retrieval with clearer result summaries.
  * Added IndusInd Bank to available bank and connector options.

* **Setup**
  * Existing installations are updated with connector configuration and beneficiary-related Bank Account fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->